### PR TITLE
Support ActiveRecord::TestFixtures#fixture_paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## [Unreleased]
 
+
+## [0.2.0]
+
 - Add support for jsonb and encrypted attributes
+- Use `TestFixtures#fixture_paths` intead of the deprecated method in singular `TestFixture#fixture_path`
 
 ## [0.1.0] - 2023-01-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 - Add support for jsonb and encrypted attributes
 - Use `TestFixtures#fixture_paths` intead of the deprecated method in singular `TestFixture#fixture_path`
+- Add partial support for multiple fixture paths
 
 ## [0.1.0] - 2023-01-23
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fixture_champagne (0.1.0)
+    fixture_champagne (0.2.0)
       rails (>= 6.1.0)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Add the `up` and `down` logic to the new migration:
 class CreateInitialEnemy < FixtureChampagne::Migration::Base
   def up
     unless Enemy.find_by(name: "Initial Enemy").present?
-      Enemy.create!(name: "Initial Enemy", level: levels(:first_level)) 
+      Enemy.create!(name: "Initial Enemy", level: levels(:first_level))
     end
   end
 
@@ -139,6 +139,9 @@ You can better control fixture migrations by creating a config YAML file: `test/
 
 Setting the `overwrite` key to `false` will leave your current fixtures untouched. The generated fixtures will go to `tmp/fixtures`. Default value is set to `true`.
 
+This feature has partial support for multiple fixture paths (Rails > 7.1). If your fixtures are divided across multiple paths (for example `test/fixtures_a` and `test/fixtues_b`), the fixture migration will fail unless you set `overwrite` to `false`. However, if you set multiple folders but only use one (all your files are in `test/fixtures_a`) then the migration can overwrite that folder.
+
+
 ```yaml
 # test/fixture_champagne.yml
 
@@ -155,7 +158,7 @@ In the previous example, you can configure:
 # test/fixture_champagne.yml
 
 label:
-  enemy: "%{name}"    
+  enemy: "%{name}"
 ```
 
 To generate:
@@ -184,7 +187,7 @@ If `rename` is set to `true`, every time you run `migrate` or `rollback` all fix
 
 Setting the `ignore` key will allow you to control which tables get saved as fixtures. It accepts an array, where items are table names. Any table ignored by this configuration will disappear from the corresponding fixture folder (depending on `overwrite`).
 
-Let's say for example that each time a new `Enemy` gets created, it creates an associated `Event` in a callback that runs some processing in the background. If that event belongs to a polymorphic `eventable`, for every single one of those, a new event will be added to your fixtures, making the `events.yml` a big but not very useful file. Or maybe events get incinerated a couple of days after execution and it makes no sense to have fixtures for them. In any of those situations, you could ignore them from fixtures like this:  
+Let's say for example that each time a new `Enemy` gets created, it creates an associated `Event` in a callback that runs some processing in the background. If that event belongs to a polymorphic `eventable`, for every single one of those, a new event will be added to your fixtures, making the `events.yml` a big but not very useful file. Or maybe events get incinerated a couple of days after execution and it makes no sense to have fixtures for them. In any of those situations, you could ignore them from fixtures like this:
 
 ```yaml
 # test/fixture_champagne.yml
@@ -238,7 +241,7 @@ And all your migrations will now have access to your existing factories. If you 
 class CreateInitialEnemy < FixtureChampagne::Migration::Base
   def up
     unless Enemy.find_by(name: "Initial Enemy").present?
-      create(:enemy, name: "Initial Enemy", level: levels(:first_level)) 
+      create(:enemy, name: "Initial Enemy", level: levels(:first_level))
     end
   end
 
@@ -259,6 +262,7 @@ The following fixture features are not supported:
 - Fixture label interpolation (favoured configuration)
 - HABTM (`have_and_belong_to_many`) associations as inline lists
 - Support for YAML defaults (this could be nice)
+- Overwriting multiple fixture paths
 
 As stated before, at least for now, fixtures files that correspond to attachments will be copied as they are. This means:
 - This fixtures must be generated manually

--- a/gemfiles/rails_6_1.gemfile.lock
+++ b/gemfiles/rails_6_1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    fixture_champagne (0.1.0)
+    fixture_champagne (0.2.0)
       rails (>= 6.1.0)
 
 GEM

--- a/gemfiles/rails_7.gemfile.lock
+++ b/gemfiles/rails_7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    fixture_champagne (0.1.0)
+    fixture_champagne (0.2.0)
       rails (>= 6.1.0)
 
 GEM

--- a/gemfiles/rails_main.gemfile.lock
+++ b/gemfiles/rails_main.gemfile.lock
@@ -97,7 +97,7 @@ GIT
 PATH
   remote: ..
   specs:
-    fixture_champagne (0.1.0)
+    fixture_champagne (0.2.0)
       rails (>= 6.1.0)
 
 GEM

--- a/lib/fixture_champagne.rb
+++ b/lib/fixture_champagne.rb
@@ -34,4 +34,6 @@ module FixtureChampagne # :nodoc:
   end
 
   class NotInTestEnvironmentError < StandardError; end # :nodoc:
+
+  class OverwriteNotAllowedError < StandardError; end # :nodoc:
 end

--- a/lib/fixture_champagne/migration_context.rb
+++ b/lib/fixture_champagne/migration_context.rb
@@ -49,13 +49,17 @@ module FixtureChampagne
         rspec_path = Rails.root.join("spec")
         minitest_path = Rails.root.join("test")
 
-        if defined?(Rspec) && rspec_path.exist?
+        if test_framework == :rspec && rspec_path.exist?
           rspec_path
         elsif minitest_path.exist?
           minitest_path
         else
           raise "No test nor spec folder found"
         end
+      end
+
+      def test_framework
+        ::Rails.application.config.generators.options[:rails][:test_framework]
       end
 
       def schema_current_version
@@ -87,7 +91,7 @@ module FixtureChampagne
       end
 
       def fixture_paths
-        paths = if defined?(Rspec)
+        paths = if test_framework == :rspec
                   rspec_fixture_paths
                 else
                   minitest_fixture_paths
@@ -96,14 +100,18 @@ module FixtureChampagne
       end
 
       def rspec_fixture_paths
-        Rspec.configuration.fixture_paths.any? ? Rspec.configuration.fixture_paths : [Rspec.configuration.fixture_path]
+        if Rspec.configuration.fixture_paths.any?
+          Rspec.configuration.fixture_paths
+        else
+          Array(Rspec.configuration.fixture_path)
+        end
       end
 
       def minitest_fixture_paths
         if ActiveSupport::TestCase.respond_to?(:fixture_paths=)
           ActiveSupport::TestCase.fixture_paths
         else
-          [ActiveSupport::TestCase.fixture_path]
+          Array(ActiveSupport::TestCase.fixture_path)
         end
       end
     end

--- a/lib/fixture_champagne/migration_context.rb
+++ b/lib/fixture_champagne/migration_context.rb
@@ -46,13 +46,13 @@ module FixtureChampagne
       end
 
       def test_suite_folder_path
-        rspec_path = Rails.root.join("test")
-        minitest_path = Rails.root.join("spec")
+        rspec_path = Rails.root.join("spec")
+        minitest_path = Rails.root.join("test")
 
-        if minitest_path.exist?
-          minitest_path
-        elsif rspec_path.exist?
+        if defined?(Rspec) && rspec_path.exist?
           rspec_path
+        elsif minitest_path.exist?
+          minitest_path
         else
           raise "No test nor spec folder found"
         end
@@ -86,8 +86,25 @@ module FixtureChampagne
         test_suite_folder_path.join("fixture_champagne.yml")
       end
 
-      def fixtures_path
-        test_suite_folder_path.join("fixtures")
+      def fixture_paths
+        paths = if defined?(Rspec)
+                  rspec_fixture_paths
+                else
+                  minitest_fixture_paths
+                end
+        paths.map { |p| Pathname.new(p) }
+      end
+
+      def rspec_fixture_paths
+        Rspec.configuration.fixture_paths.any? ? Rspec.configuration.fixture_paths : [Rspec.configuration.fixture_path]
+      end
+
+      def minitest_fixture_paths
+        if ActiveSupport::TestCase.respond_to?(:fixture_paths=)
+          ActiveSupport::TestCase.fixture_paths
+        else
+          [ActiveSupport::TestCase.fixture_path]
+        end
       end
     end
 

--- a/lib/fixture_champagne/migrator.rb
+++ b/lib/fixture_champagne/migrator.rb
@@ -24,7 +24,7 @@ module FixtureChampagne
       end
 
       def fixture_attachment_folders
-        %w[files active_storage action_text].map { |f| fixture_path.join(f) }
+        %w[files active_storage action_text].map { |f| single_fixture_path.join(f) }
       end
     end
 
@@ -188,9 +188,9 @@ module FixtureChampagne
     end
 
     def overwrite_fixtures
-      removable_fixture_path = self.class.fixture_path.dirname.join("old_fixtures")
-      FileUtils.mv(self.class.fixture_path, removable_fixture_path)
-      FileUtils.mv(self.class.tmp_fixture_path, self.class.fixture_path)
+      removable_fixture_path = self.class.single_fixture_path.dirname.join("old_fixtures")
+      FileUtils.mv(self.class.single_fixture_path, removable_fixture_path)
+      FileUtils.mv(self.class.tmp_fixture_path, self.class.single_fixture_path)
       FileUtils.rm_r(removable_fixture_path, secure: true)
     end
 

--- a/lib/fixture_champagne/test_fixtures.rb
+++ b/lib/fixture_champagne/test_fixtures.rb
@@ -12,22 +12,11 @@ module FixtureChampagne
 
     included do
       if respond_to?(:fixture_paths)
-        fixture_paths << MigrationContext.fixture_paths
+        self.fixture_paths = MigrationContext.fixture_paths
       else
         self.fixture_path = MigrationContext.fixture_paths.first
       end
       fixtures :all
-    end
-
-    class_methods do
-      # FIXME: Should implement a strategy to regenerate different fixture folders
-      def single_fixture_path
-        if respond_to?(:fixture_paths)
-          fixture_paths.first
-        else
-          fixture_path
-        end
-      end
     end
 
     def name

--- a/lib/fixture_champagne/test_fixtures.rb
+++ b/lib/fixture_champagne/test_fixtures.rb
@@ -11,8 +11,23 @@ module FixtureChampagne
     include ActiveRecord::TestFixtures
 
     included do
-      self.fixture_path = MigrationContext.fixtures_path
+      if respond_to?(:fixture_paths)
+        fixture_paths << MigrationContext.fixture_paths
+      else
+        self.fixture_path = MigrationContext.fixture_paths.first
+      end
       fixtures :all
+    end
+
+    class_methods do
+      # FIXME: Should implement a strategy to regenerate different fixture folders
+      def single_fixture_path
+        if respond_to?(:fixture_paths)
+          fixture_paths.first
+        else
+          fixture_path
+        end
+      end
     end
 
     def name

--- a/lib/fixture_champagne/version.rb
+++ b/lib/fixture_champagne/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FixtureChampagne
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end

--- a/test/fixture_champagne/migration_context_test.rb
+++ b/test/fixture_champagne/migration_context_test.rb
@@ -25,8 +25,8 @@ class MigrationContextTest < ActiveSupport::TestCase
                  Rails.root.join("test", "fixture_migrations"))
   end
 
-  test "fixture_path" do
-    assert_equal(FixtureChampagne::MigrationContext.fixtures_path, Rails.root.join("test", "fixtures"))
+  test "fixture_paths" do
+    assert_equal(FixtureChampagne::MigrationContext.fixture_paths, [Rails.root.join("test", "fixtures")])
   end
 
   test "configuration_path" do

--- a/test/fixture_champagne/migrator_test.rb
+++ b/test/fixture_champagne/migrator_test.rb
@@ -26,7 +26,7 @@ class MigratorTest < ActiveSupport::TestCase
   # FIXME: This logic might find a better place elsewhere. For now, it's only used here as parsing
   #        fixture files without initializing records is not required in any other process
   def parse_temporary_fixture_folder
-    Dir.glob("#{FixtureChampagne::Migrator.tmp_fixture_path}/**/*.yml").each_with_object({}) do |path, mapping|
+    Dir.glob("#{FixtureChampagne::Migrator::TMP_FIXTURE_PATH}/**/*.yml").each_with_object({}) do |path, mapping|
       key = path.scan(%r{.*/fixtures/(.*)\.yml}).first.first
       mapping[key] = {}
       ActiveRecord::FixtureSet::File.open(path).each { |row| mapping[key][row.first] = row.last }
@@ -34,7 +34,7 @@ class MigratorTest < ActiveSupport::TestCase
   end
 
   def remove_temporary_fixture_folder
-    FileUtils.rm_rf(FixtureChampagne::Migrator.tmp_fixture_path)
+    FileUtils.rm_rf(FixtureChampagne::Migrator::TMP_FIXTURE_PATH)
   end
 
   setup do
@@ -49,7 +49,7 @@ class MigratorTest < ActiveSupport::TestCase
   teardown { remove_temporary_fixture_folder }
 
   test "tmp_fixture_path" do
-    assert_equal(FixtureChampagne::Migrator.tmp_fixture_path, Rails.root.join("tmp", "fixtures"))
+    assert_equal(FixtureChampagne::Migrator::TMP_FIXTURE_PATH, Rails.root.join("tmp", "fixtures"))
   end
 
   test "fixture_attachment_folders" do

--- a/test/fixture_champagne/migrator_test.rb
+++ b/test/fixture_champagne/migrator_test.rb
@@ -53,7 +53,15 @@ class MigratorTest < ActiveSupport::TestCase
   end
 
   test "fixture_attachment_folders" do
-    attachment_folders = FixtureChampagne::Migrator.fixture_attachment_folders
+    migrator = FixtureChampagne::Migrator.new(
+      direction: :up,
+      migrations: @available_migrations,
+      target_migration_version: @available_migrations.map(&:version).max,
+      target_schema_version: FixtureChampagne::MigrationContext.schema_current_version,
+      configuration: FixtureChampagne::MigrationContext::Configuration.new(overwrite: false)
+    )
+
+    attachment_folders = migrator.fixture_attachment_folders
 
     assert_includes(attachment_folders, Rails.root.join("test", "fixtures", "files"))
     assert_includes(attachment_folders, Rails.root.join("test", "fixtures", "active_storage"))

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,11 +8,16 @@ ActiveRecord::Migrator.migrations_paths = [File.expand_path("../test/dummy/db/mi
 require "rails/test_help"
 
 # Load fixtures from the engine
-if ActiveSupport::TestCase.respond_to?(:fixture_path=)
+if ActiveSupport::TestCase.respond_to?(:fixture_paths=)
+  ActiveSupport::TestCase.fixture_paths = [File.expand_path("dummy/test/fixtures", __dir__)]
+  ActionDispatch::IntegrationTest.fixture_paths = ActiveSupport::TestCase.fixture_paths
+else
+  # TODO: This will be removed in Rails 7.2
   ActiveSupport::TestCase.fixture_path = File.expand_path("dummy/test/fixtures", __dir__)
   ActionDispatch::IntegrationTest.fixture_path = ActiveSupport::TestCase.fixture_path
-  ActiveSupport::TestCase.file_fixture_path = "#{ActiveSupport::TestCase.fixture_path}/files"
-  ActiveSupport::TestCase.fixtures :all
 end
+
+ActiveSupport::TestCase.file_fixture_path = File.expand_path("dummy/test/fixtures/files", __dir__)
+ActiveSupport::TestCase.fixtures :all
 
 require "minitest/mock"


### PR DESCRIPTION
Rails deprecated #fixture_path in 7.1, planning to remove it in 7.2. The new config accepts an array of paths.

From Rails 7.1 users can set multiple fixture paths, the default being test/fixtures.
Most users will use the default path. Others may use a custom path but keep the default in the array, even if they do not use it. For now the gem supports only these 2 cases.

If a user has fixture files in multiple paths, then it's trickier to decide where to save the new generated fixtures, so for now the gem will not allow these users to overwrite current files. They can still generate all fixtures in a tmp folder.